### PR TITLE
mobXDevTools Flag & Update normalize.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ storiesOf('helpers.storybook', module)
 
 ```js
 host({
+  mobXDevTools: <boolean>,
   title: <string>,
   hr: <boolean>,
   align: <string>,
@@ -54,7 +55,8 @@ host({
   padding: <number | string>,
 });
 ```
-
+#### `mobXDevTools: boolean`
+Flag indicating if the mobXDevTools at the bottom should be shown.  Default: `true`.
 
 #### `title: string`
 The title display that is displayed at the top of the window.
@@ -62,7 +64,6 @@ Use this to to name and provide a decription of the component under test.
 
 #### `hr: boolean`
 Flag indicating if the horizontal rule under the title should be shown.  Default: `true`.
-
 
 #### `align: string [x y]`
 A string indicating how to align the component within the host. The string takes to parts (`x` and `y`) 

--- a/assets/css/normalize.css
+++ b/assets/css/normalize.css
@@ -1,15 +1,24 @@
-/*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
 
 /**
  * 1. Change the default font family in all browsers (opinionated).
- * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
  */
+
+/* Document
+   ========================================================================== */
 
 html {
   font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  line-height: 1.15; /* 2 */
+  -ms-text-size-adjust: 100%; /* 3 */
+  -webkit-text-size-adjust: 100%; /* 3 */
 }
+
+/* Sections
+   ========================================================================== */
 
 /**
  * Remove the margin in all browsers (opinionated).
@@ -19,69 +28,73 @@ body {
   margin: 0;
 }
 
-/* HTML5 display definitions
-   ========================================================================== */
-
 /**
  * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
- * 2. Add the correct display in IE.
  */
 
 article,
 aside,
-details, /* 1 */
-figcaption,
-figure,
 footer,
 header,
-main, /* 2 */
-menu,
 nav,
-section,
-summary { /* 1 */
+section {
   display: block;
 }
 
 /**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
  * Add the correct display in IE 9-.
- */
-
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-}
-
-/**
- * Add the correct display in iOS 4-7.
- */
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-/**
- * Add the correct vertical alignment in Chrome, Firefox, and Opera.
- */
-
-progress {
-  vertical-align: baseline;
-}
-
-/**
- * Add the correct display in IE 10-.
  * 1. Add the correct display in IE.
  */
 
-template, /* 1 */
-[hidden] {
-  display: none;
+figcaption,
+figure,
+main { /* 1 */
+  display: block;
 }
 
-/* Links
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
    ========================================================================== */
 
 /**
@@ -103,9 +116,6 @@ a:active,
 a:hover {
   outline-width: 0;
 }
-
-/* Text-level semantics
-   ========================================================================== */
 
 /**
  * 1. Remove the bottom border in Firefox 39-.
@@ -137,21 +147,23 @@ strong {
 }
 
 /**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
  * Add the correct font style in Android 4.3-.
  */
 
 dfn {
   font-style: italic;
-}
-
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
 }
 
 /**
@@ -196,6 +208,24 @@ sup {
    ========================================================================== */
 
 /**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
  * Remove the border on images inside links in IE 10-.
  */
 
@@ -211,63 +241,23 @@ svg:not(:root) {
   overflow: hidden;
 }
 
-/* Grouping content
-   ========================================================================== */
-
-/**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
- */
-
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
-}
-
-/**
- * Add the correct margin in IE 8.
- */
-
-figure {
-  margin: 1em 40px;
-}
-
-/**
- * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
- */
-
-hr {
-  box-sizing: content-box; /* 1 */
-  height: 0; /* 1 */
-  overflow: visible; /* 2 */
-}
-
 /* Forms
    ========================================================================== */
 
 /**
- * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 1. Change the font styles in all browsers (opinionated).
  * 2. Remove the margin in Firefox and Safari.
  */
 
 button,
 input,
+optgroup,
 select,
 textarea {
-  font: inherit; /* 1 */
+  font-family: sans-serif; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
   margin: 0; /* 2 */
-}
-
-/**
- * Restore the font weight unset by the previous rule.
- */
-
-optgroup {
-  font-weight: bold;
 }
 
 /**
@@ -353,6 +343,16 @@ legend {
 }
 
 /**
+ * 1. Add the correct display in IE 9-.
+ * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
  * Remove the default vertical scrollbar in IE.
  */
 
@@ -391,21 +391,12 @@ textarea {
 }
 
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
  */
 
 [type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
-}
-
-/**
- * Correct the text style of placeholders in Chrome, Edge, and Safari.
- */
-
-::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
 }
 
 /**
@@ -416,4 +407,55 @@ textarea {
 ::-webkit-file-upload-button {
   -webkit-appearance: button; /* 1 */
   font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ */
+
+details, /* 1 */
+menu {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Scripting
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+canvas {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+template {
+  display: none;
+}
+
+/* Hidden
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10-.
+ */
+
+[hidden] {
+  display: none;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-host",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A React Storybook decorator with helpful display options for hosting components under test",
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",

--- a/src/components/ComponentHost.stories.tsx
+++ b/src/components/ComponentHost.stories.tsx
@@ -35,7 +35,14 @@ storiesOf(STORY_TITLE, module)
     return el;
   });
 
-
+storiesOf(STORY_TITLE, module)
+  .addDecorator(host({
+    title: 'Foo',
+    mobXDevTools: false,
+  }))
+  .add('No mobXDevTools', () => {
+    return el;
+  });
 
 storiesOf(STORY_TITLE, module)
   .addDecorator(host({ title: 'Foo', backdrop: true }))
@@ -64,7 +71,3 @@ storiesOf(STORY_TITLE, module)
 storiesOf(STORY_TITLE, module)
   .addDecorator(host({ title: 'Foo', backdrop: -0.1, background: 1, border: -0.3 }))
   .add('backdrop: -0.1, background: 1', () => el);
-
-
-
-

--- a/src/components/ComponentHost.tsx
+++ b/src/components/ComponentHost.tsx
@@ -8,6 +8,7 @@ import MobXDevTools from 'mobx-react-devtools';
 const RED = 'rgba(255, 0, 0, 0.1)';
 
 export interface IHostProps {
+  mobXDevTools?: boolean;
   title?: string;
   hr?: boolean;
   padding?: number | string | Array<number>;
@@ -34,6 +35,7 @@ export interface IComponentHostProps {
 const ComponentHost = Radium((props: IComponentHostProps & IHostProps) => {
   let {
     story,
+    mobXDevTools = true,
     title,
     align,
     width,
@@ -120,7 +122,9 @@ const ComponentHost = Radium((props: IComponentHostProps & IHostProps) => {
           </CropMarks>
         </AlignmentContainer>
       </div>
-      <MobXDevTools position={{ bottom: -1, right: -1 }} />
+      {mobXDevTools &&
+        <MobXDevTools position={{ bottom: -1, right: -1 }} />
+      }
     </div>
   );
 });


### PR DESCRIPTION
- Add a `bool` to turn off/on the `mobXDevTools` (Closes #3)
- Updates outdated `normalize.css` from `v4.1.1` to `v5.0.0`
- Bumps version of `storybook-host` to `1.0.8`