### PR TITLE
Remove unused imports and take @storybook/react typings from @types

### DIFF
--- a/src/components/ComponentHost.stories.tsx
+++ b/src/components/ComponentHost.stories.tsx
@@ -1,5 +1,6 @@
+import { storiesOf } from '@storybook/react';
 import * as React from 'react';
-import { storiesOf, host } from '..';
+import { host } from '..';
 
 const STORY = 'helpers.storybook';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
 import '../assets/css/normalize.css';
-import * as knobs from '@storybook/addon-knobs';
 
-export { knobs };
-export { Story, storiesOf } from '@storybook/react';
 export { R, Radium, css } from './common';
 export { host, host as default, IHostProps } from './decorators/host';
 export { AlignEdge } from './types';


### PR DESCRIPTION
I removed exports from index file and instead import dependencies directly from the source. This was causing issues in my project as `action` has been removed from @storybook/react typings and it's been moved to a  separate package. Also, it wasn't actually used in the project.

And knobs was used only in dev env so I removed it from index file as well.