### PR TITLE
Remove normalize.css

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import '../assets/css/normalize.css';
-
 export { R, Radium, css } from './common';
 export { host, host as default, IHostProps } from './decorators/host';
 export { AlignEdge } from './types';


### PR DESCRIPTION
This quick change removes the `normalize.css` file so that it does not interfere with custom CSS imported into `storybook`
See https://github.com/philcockfield/storybook-host/issues/14

A brief test at my desk reveals that removing normalize shifts the overall container to be a little bit wider, but was otherwise not a noticeable change.  Anecdotal, I know, but clearly it is not critical to the success of the addon.